### PR TITLE
Fixed a mistake in manifest

### DIFF
--- a/CSK_Module_IODDInterpreter/project.mf.xml
+++ b/CSK_Module_IODDInterpreter/project.mf.xml
@@ -204,15 +204,15 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
                     <desc>Function to process the selected row in process data in dynamic table that was selected in another CSK module.</desc>
                     <param desc="JSON row data." multiplicity="1" name="jsonSelectedRow" type="string"/>
                     <param desc="Optional prefix to be removed from column names." multiplicity="?" name="prefix" type="string"/>
-                    <param desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
-                    <param desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
+                    <return desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
+                    <return desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
                 </function>
                 <function name="processDataOutRowSelected">
                     <desc>Function to process the selected row in process data out dynamic table in UI.</desc>
                     <param desc="JSON row data." multiplicity="1" name="jsonSelectedRow" type="string"/>
                     <param desc="Optional prefix to be reemoved from column names." multiplicity="?" name="prefix" type="string"/>
-                    <param desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
-                    <param desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
+                    <return desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
+                    <return desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
                 </function>
                 <function name="addIODDFile">
                     <desc>Add a new IODD file to be interpreted. Returns success of interpretation and new internal  name of IODD file created according to IODD file name standard.</desc>
@@ -372,16 +372,16 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
                     <desc>Function to process the selected row of read parameters dynamic table in UI of external app.</desc>
                     <param desc="JSON row data." multiplicity="1" name="jsonSelectedRow" type="string"/>
                     <param desc="Optional prefix to be removed from column names." multiplicity="?" name="prefix" type="string"/>
-                    <param desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
-                    <param desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
+                    <return desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
+                    <return desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
                 </function>
                 <function name="writeParameterRowSelected">
                     <trait>released</trait>
                     <desc>Function to process the selected row of write parameters dynamic table in UI of external app.</desc>
                     <param desc="JSON row data." multiplicity="1" name="jsonSelectedRow" type="string"/>
                     <param desc="Optional prefix to be removed from column names." multiplicity="?" name="prefix" type="string"/>
-                    <param desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
-                    <param desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
+                    <return desc="JSON template of new combined message." multiplicity="1" name="jsonTemplate" type="string"/>
+                    <return desc="JSON object with datapoints infos." multiplicity="1" name="jsonDataInfo" type="string"/>
                 </function>
                 <function name="getReadDataTableContents">
                     <trait>released</trait>

--- a/CSK_Module_IODDInterpreter/project.mf.xml
+++ b/CSK_Module_IODDInterpreter/project.mf.xml
@@ -475,7 +475,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">1.1.0</meta>
+        <meta key="version">2.0.0</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
@@ -709,7 +709,6 @@ local function processDataInRowSelected(jsonSelectedRow, prefix)
     ioddInterpreter_Model.parameters.instances[selectedInstance].selectedProcessDataIn
   )
   local jsonTemplate, jsonDataInfo = ioddInterpreter_Model.getReadDataJsonTemplateAndInfo(selectedInstance)
-  print(jsonDataInfo)
   return jsonTemplate, jsonDataInfo
 end
 Script.serveFunction('CSK_IODDInterpreter.processDataInRowSelected', processDataInRowSelected)

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
@@ -709,6 +709,7 @@ local function processDataInRowSelected(jsonSelectedRow, prefix)
     ioddInterpreter_Model.parameters.instances[selectedInstance].selectedProcessDataIn
   )
   local jsonTemplate, jsonDataInfo = ioddInterpreter_Model.getReadDataJsonTemplateAndInfo(selectedInstance)
+  print(jsonDataInfo)
   return jsonTemplate, jsonDataInfo
 end
 Script.serveFunction('CSK_IODDInterpreter.processDataInRowSelected', processDataInRowSelected)

--- a/docu/CSK_Module_IODDInterpreter.html
+++ b/docu/CSK_Module_IODDInterpreter.html
@@ -619,7 +619,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
 <span id="revnumber">version 1.1.0,</span>
-<span id="revdate">2024-10-17</span>
+<span id="revdate">2024-10-21</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -759,7 +759,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-10-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-10-21</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -2873,6 +2873,27 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Optional prefix to be removed from column names.</p></td>
 </tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_return_values_26">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
@@ -2892,7 +2913,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <h6 id="_sample_auto_generated_36">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_IODDInterpreter.processDataInRowSelected(jsonSelectedRow, prefix, jsonTemplate, jsonDataInfo)</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.processDataInRowSelected(jsonSelectedRow, prefix)</code></pre>
 </div>
 </div>
 </div>
@@ -2979,6 +3000,27 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Optional prefix to be reemoved from column names.</p></td>
 </tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_return_values_27">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
@@ -2998,7 +3040,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <h6 id="_sample_auto_generated_38">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_IODDInterpreter.processDataOutRowSelected(jsonSelectedRow, prefix, jsonTemplate, jsonDataInfo)</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.processDataOutRowSelected(jsonSelectedRow, prefix)</code></pre>
 </div>
 </div>
 </div>
@@ -3085,6 +3127,27 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Optional prefix to be removed from column names.</p></td>
 </tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_return_values_28">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
@@ -3104,7 +3167,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <h6 id="_sample_auto_generated_40">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_IODDInterpreter.readParameterRowSelected(jsonSelectedRow, prefix, jsonTemplate, jsonDataInfo)</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.readParameterRowSelected(jsonSelectedRow, prefix)</code></pre>
 </div>
 </div>
 </div>
@@ -3677,7 +3740,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 </table>
 </div>
 <div class="sect5">
-<h6 id="_return_values_26">Return values</h6>
+<h6 id="_return_values_29">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3926,6 +3989,27 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Optional prefix to be removed from column names.</p></td>
 </tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_return_values_30">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">jsonTemplate</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
@@ -3945,7 +4029,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
 <h6 id="_sample_auto_generated_57">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_IODDInterpreter.writeParameterRowSelected(jsonSelectedRow, prefix, jsonTemplate, jsonDataInfo)</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">jsonTemplate, jsonDataInfo = CSK_IODDInterpreter.writeParameterRowSelected(jsonSelectedRow, prefix)</code></pre>
 </div>
 </div>
 </div>
@@ -5451,7 +5535,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 1.1.0<br>
-Last updated 2024-10-17 12:27:28 +0200
+Last updated 2024-10-21 10:50:46 +0200
 </div>
 </div>
 <script type="text/javascript">

--- a/docu/CSK_Module_IODDInterpreter.html
+++ b/docu/CSK_Module_IODDInterpreter.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_IODDInterpreter 1.1.0</title>
+<title>Documentation - CSK_Module_IODDInterpreter 2.0.0</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_IODDInterpreter 1.1.0</h1>
+<h1>Documentation - CSK_Module_IODDInterpreter 2.0.0</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 1.1.0,</span>
+<span id="revnumber">version 2.0.0,</span>
 <span id="revdate">2024-10-21</span>
 </div>
 <div id="toc" class="toc2">
@@ -755,7 +755,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1.1.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2.0.0</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -5534,8 +5534,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 1.1.0<br>
-Last updated 2024-10-21 10:50:46 +0200
+Version 2.0.0<br>
+Last updated 2024-10-21 10:59:27 +0200
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version 2.0.0

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
