### PR TITLE
Subindex read support

### DIFF
--- a/CSK_Module_IODDInterpreter/project.mf.xml
+++ b/CSK_Module_IODDInterpreter/project.mf.xml
@@ -475,7 +475,7 @@ Module can provide chunks of IODD file in JSON format to describe some datapoint
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">2.0.0</meta>
+        <meta key="version">2.1.0</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/IODDInterpreter_Controller.lua
@@ -311,15 +311,7 @@ local function updateSelectedProcessDataTable(selectedRow, selectedProcessDataTa
     if state == false and selectedProcessDataTable["0"] == true then
       selectedProcessDataTable["0"] = false
     end
-    if selectedProcessDataTable.subindexAccessSupported == true then
-      selectedProcessDataTable[subindex] = state
-    else
-      for tempSubndex, _ in pairs(selectedProcessDataTable) do
-        if tempSubndex ~= "subindexAccessSupported" then
-          selectedProcessDataTable[tempSubndex] = state
-        end
-      end
-    end
+    selectedProcessDataTable[subindex] = state
   else
     for tempSubndex, _ in pairs(selectedProcessDataTable) do
       if tempSubndex ~= "subindexAccessSupported" then
@@ -340,15 +332,7 @@ local function updateSelectedParametersTable(selectedRow, selectedParametersTabl
     if state == false and selectedParametersTable[index]["0"] == true then
       selectedParametersTable[index]["0"] = false
     end
-    if selectedParametersTable[index].subindexAccessSupported == true then
-      selectedParametersTable[index][subindex] = state
-    else
-      for subindex1, _ in pairs(selectedParametersTable[index]) do
-        if subindex1 ~= "subindexAccessSupported" then
-          selectedParametersTable[index][subindex1] = state
-        end
-      end
-    end
+    selectedParametersTable[index][subindex] = state
   else
     for subindex1, _ in pairs(selectedParametersTable[index]) do
       if subindex1 ~= "subindexAccessSupported" then

--- a/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/helper/IODDInterpreter.lua
+++ b/CSK_Module_IODDInterpreter/scripts/Sensors/IODDInterpreter/helper/IODDInterpreter.lua
@@ -47,9 +47,15 @@ end
 
 function IODDInterpreter:getSubIndexParameter(index, subindex)
   if self.ParamIndexMap[index] and self.ParamIndexSubindexMap[index][subindex] then
-    local tempTable = copy(self.Variable[self.ParamIndexMap[index]].Datatype.RecordItem[self.ParamIndexSubindexMap[index][subindex]])
-    changeTextIDtoText(tempTable, self.languages[self.currentLanguage])
-    return tempTable
+    if self.Variable[self.ParamIndexMap[index]].Datatype['xsi:type'] == "ArrayT" then
+      local tempTable = copy(self.Variable[self.ParamIndexMap[index]].Datatype.SimpleDatatype)
+      changeTextIDtoText(tempTable, self.languages[self.currentLanguage])
+      return tempTable
+    else
+      local tempTable = copy(self.Variable[self.ParamIndexMap[index]].Datatype.RecordItem[self.ParamIndexSubindexMap[index][subindex]])
+      changeTextIDtoText(tempTable, self.languages[self.currentLanguage])
+      return tempTable
+    end
   else
     return false
   end


### PR DESCRIPTION
# Version 2.1.0

## Improvements

### Now user can select a subindex to read even if subindex access is not supported 

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
